### PR TITLE
fix nan to num (0.1.4)

### DIFF
--- a/napari_svg/xml_to_svg.py
+++ b/napari_svg/xml_to_svg.py
@@ -20,7 +20,7 @@ def xml_to_svg(xml_list, extrema):
         SVG representation of the layer.
     """
 
-    extrema = np.nan_to_num(extrema, nan=0)
+    extrema = np.nan_to_num(extrema)
 
     corner = extrema[0]
     shape = extrema[1] - extrema[0]

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 imageio>=2.5.0
-numpy>=1.10.0
+numpy>=1.16.0
 napari-plugin-engine>=0.1.4
 vispy >= 0.6.4

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(osp.join('requirements', 'default.txt')) as f:
 
 setup(
     name='napari-svg',
-    version='0.1.3',
+    version='0.1.4',
     author='Nicholas Sofroniew',
     author_email='sofroniewn@gmail.com',
     maintainer='Nicholas Sofroniew',


### PR DESCRIPTION
Following on from https://github.com/napari/napari/pull/1613 and https://github.com/napari/napari/pull/1617 this fixes our an `np.num_to_nan` bug that was happening on any numpy version `<0.1.17`. As napari still supports numpy `0.1.16` we have fixed this. We've also suppressed a warning that napari suppresses and have bumped the version of `napari-svg` to `0.1.4`