### PR TITLE
handle isotropic pt size

### DIFF
--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -153,7 +153,9 @@ def points_to_xml(data, meta):
     """
     # Extract metadata parameters
     if 'size' in meta:
-        size = np.mean(meta['size'], axis=1)
+        size = meta['size']
+        if size.ndim == 2:
+            size = np.mean(size, axis=1)
     else:
         size = np.ones(data.shape[0])
 


### PR DESCRIPTION
This change does nothing for the current napari version, but is necessary to handle the change from anisotropic point sizes to isotropic (napari/napari#5582). Without this changes, saving points as svg fails.


