### PR TITLE
Use napari colormaps (allowing non-vispy and custom ones)

### DIFF
--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -153,7 +153,9 @@ def points_to_xml(data, meta):
     """
     # Extract metadata parameters
     if 'size' in meta:
-        size = np.mean(meta['size'], axis=1)
+        size = meta['size']
+        if size.ndim == 2:
+            size = np.mean(size, axis=1)
     else:
         size = np.ones(data.shape[0])
 

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -148,6 +148,7 @@ def points_to_xml(data, meta):
     if 'size' in meta:
         size = meta['size']
         if size.ndim == 2:
+            # backward compatibility for napari<v0.4.18 with anisotropic sizes
             size = np.mean(size, axis=1)
     else:
         size = np.ones(data.shape[0])

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 import numpy as np
 from copy import copy
 from imageio import imwrite
+from napari.utils.colormaps.colormap_utils import ensure_colormap
 from vispy.color import get_colormap
 from ._shape_to_xml import (
     ellipse_to_xml,
@@ -20,6 +21,23 @@ shape_type_to_xml = {
     'polygon': polygon_to_xml,
     'rectangle': rectangle_to_xml,
 }
+
+
+def _apply_vispy_colormap(image, colormap_name):
+    # convert 'gray' colormap name to 'grays' for vispy compatibility
+    # see: https://github.com/napari/napari-svg/pull/12
+    if colormap_name == 'gray':
+        colormap_name = 'grays'
+
+    cmap = get_colormap(colormap_name)
+
+    return cmap[image.ravel()].RGBA.reshape(image.shape + (4,))
+
+
+def _apply_napari_colormap(image, colormap):
+    cmap = ensure_colormap(colormap)
+
+    return np.round(cmap.map(image) * 225)
 
 
 def image_to_xml(data, meta):
@@ -65,14 +83,14 @@ def image_to_xml(data, meta):
         contrast_limits = [0, 1]
 
     if 'colormap' in meta:
-        colormap_name = meta['colormap']
-
-        # convert 'gray' colormap name to 'grays' for vispy compatibility
-        # see: https://github.com/napari/napari-svg/pull/12
-        if colormap_name == 'gray':
-            colormap_name = 'grays'
+        colormap = meta['colormap']
+        if isinstance(colormap, str):
+            # fallback for backward compatibility
+            apply_colormap = lambda image: _apply_vispy_colormap(image, colormap)
+        else:
+            apply_colormap = lambda image: _apply_napari_colormap(image, colormap)
     else:
-        colormap_name = 'grays'
+        apply_colormap = lambda image: _apply_vispy_colormap(image, 'grays')
 
     if 'opacity' in meta:
         opacity = meta['opacity']
@@ -104,14 +122,7 @@ def image_to_xml(data, meta):
         if color_range != 0:
             image = image / color_range
 
-        # get colormap
-        # TODO: Currently we only support vispy colormaps, need to
-        # add support for all napari colormaps, matters for Labels too.
-        cmap = get_colormap(colormap_name)
-            
-        # apply colormap to data
-        mapped_image = cmap[image.ravel()]
-        mapped_image = mapped_image.RGBA.reshape(image.shape + (4,))
+        mapped_image = apply_colormap(image)
 
     image_str = imwrite('<bytes>', mapped_image, format='png')
     image_str = "data:image/png;base64," + str(b64encode(image_str))[2:-1]
@@ -124,7 +135,7 @@ def image_to_xml(data, meta):
         'image', width=width, height=height, opacity=str(opacity), **props
     )
     xml_list = [xml]
-    
+
     return xml_list, extrema
 
 

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -102,8 +102,8 @@ def image_to_xml(data, meta):
 
         cmap = ensure_colormap(colormap)
 
-        # to keep backward comaptybility with napari before 0.4.18
-        # to workaround bug in `vmap.map` we need ro ravel and reshape
+        # to keep backward compatibility with napari <0.4.18
+        # because of a bug in `vmap.map`, we need to ravel, map, then reshape
         mapped_image = (cmap.map(image.ravel()).reshape(image.shape + (4,)) * 255).astype(np.uint8)
 
     image_str = imwrite('<bytes>', mapped_image, format='png')

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     numpy>=1.16.0
     napari-plugin-engine>=0.1.4
     vispy>=0.6.4
-    napari>=0.4
+    napari>=0.4.18
 
 [options.extras_require]
 testing =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,12 @@ install_requires =
     numpy>=1.16.0
     napari-plugin-engine>=0.1.4
     vispy >= 0.6.4
+    napari >= 0.4
 
 [options.extras_require]
 testing =
     pytest
     pytest-cov
-    napari >= 0.4
     pyqt5
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ install_requires =
     imageio>=2.5.0
     numpy>=1.16.0
     napari-plugin-engine>=0.1.4
-    vispy >= 0.6.4
-    napari >= 0.4
+    vispy>=0.6.4
+    napari>=0.4
 
 [options.extras_require]
 testing =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,8 @@ install_requires =
 testing =
     pytest
     pytest-cov
-    napari[pyqt5]>=0.2.12
+    napari
+    pyqt5
 
 [options.entry_points]
 napari.plugin =


### PR DESCRIPTION
Switch from vispy colormap to napari colormaps for mapping. This is needed for napari/napari#5782 to work. On the flipside, napari/napari#5805 is neede for this PR, because napari's `Colormap.map()` is currently broken.

I'm currently not sure how to get this in a way that does not break backward compatibility, yet allowing forward compatibillity for when we finally release the aformenentioned changes from napari. We might just have to do a quick release of this plugin right after napari to ensure it's good.