### PR TITLE
Add napari dep

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 imageio>=2.5.0
 numpy>=1.16.0
 napari-plugin-engine>=0.1.4
-vispy >= 0.6.4
+napari>=0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     imageio>=2.5.0
     numpy>=1.16.0
     napari-plugin-engine>=0.1.4
-    vispy>=0.6.4
+    napari>=0.4.0
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
As pointed out in #32, napari should now be in the dependencies, while vispy is no longer a direct dependency.

Probably doesn't matter for most normal uses, so there's shouldn't be too much consequence in the wild, but better to fix this.


