### PR TITLE
Fix border color and width

### DIFF
--- a/napari_svg/_tests/test_write_layer.py
+++ b/napari_svg/_tests/test_write_layer.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import pytest
+from pathlib import Path
 from napari.layers import Image, Points, Labels, Shapes, Vectors
 from napari.utils.colormaps.colormap_utils import ensure_colormap
 from napari_svg import (
@@ -161,3 +162,33 @@ def test_write_image_colormaps_vispy(tmpdir, layer_writer_and_data, path_ensure,
 
     # Check file now exists
     assert os.path.isfile(path)
+
+
+def test_write_points_with_attributes(request, tmp_path):
+    data = [
+        [0, 0],
+        [0, 128],
+        [128, 128],
+    ]
+    size = [16, 20, 24]
+    face_color = ['red', 'green', 'blue']
+    border_color = ['cyan', 'magenta', 'yellow']
+    border_width = [0.05, 0.25, 0.5]
+    layer = Points(
+        data,
+        opacity=0.5,
+        size=size,
+        face_color=face_color,
+        border_color=border_color,
+        border_width=border_width,
+        border_width_is_relative=True,
+    )
+    test_name = request.node.name
+    path = tmp_path / f'{test_name}-actual.svg'
+    layer_data, layer_attrs, _ = layer.as_layer_data_tuple()
+
+    return_path = napari_write_points(path, layer_data, layer_attrs)
+    assert return_path == path
+
+    expected_path = Path(__file__).parent / f'{test_name}-expected.svg'
+    assert path.read_text() == expected_path.read_text()

--- a/napari_svg/_tests/test_write_layer.py
+++ b/napari_svg/_tests/test_write_layer.py
@@ -172,16 +172,16 @@ def test_write_points_with_attributes(request, tmp_path):
     ]
     size = [16, 20, 24]
     face_color = ['red', 'green', 'blue']
-    border_color = ['cyan', 'magenta', 'yellow']
-    border_width = [0.05, 0.25, 0.5]
+    edge_color = ['cyan', 'magenta', 'yellow']
+    edge_width = [0.05, 0.25, 0.5]
     layer = Points(
         data,
         opacity=0.5,
         size=size,
         face_color=face_color,
-        border_color=border_color,
-        border_width=border_width,
-        border_width_is_relative=True,
+        edge_color=edge_color,
+        edge_width=edge_width,
+        edge_width_is_relative=True,
     )
     test_name = request.node.name
     path = tmp_path / f'{test_name}-actual.svg'

--- a/napari_svg/_tests/test_write_points_with_attributes-expected.svg
+++ b/napari_svg/_tests/test_write_points_with_attributes-expected.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg height="128" width="128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g transform="translate(0 0)"><circle cx="0" cy="0" r="8.0" stroke="rgb(0, 255, 255)" fill="rgb(255, 0, 0)" stroke-width="0.8" opacity="0.5" /><circle cx="128" cy="0" r="10.0" stroke="rgb(255, 0, 255)" fill="rgb(0, 128, 0)" stroke-width="5.0" opacity="0.5" /><circle cx="128" cy="128" r="12.0" stroke="rgb(255, 255, 0)" fill="rgb(0, 0, 255)" stroke-width="12.0" opacity="0.5" /></g></svg>

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -178,16 +178,20 @@ def points_to_xml(data, meta):
     else:
         face_color = np.ones((data.shape[0], 4))
 
-    if 'edge_color' in meta:
-        edge_color = meta['edge_color']
+    if 'border_color' in meta:
+        stroke_color = meta['border_color']
+    elif 'edge_color' in meta:
+        stroke_color = meta['edge_color']
     else:
-        edge_color = np.zeros((data.shape[0], 4))
-        edge_color[:, 3] = 1
+        stroke_color = np.zeros((data.shape[0], 4))
+        stroke_color[:, 3] = 1
 
-    if 'edge_width' in meta:
-        edge_width = meta['edge_width']
+    if 'border_width' in meta:
+        stroke_width = meta['border_width']
+    elif 'edge_width' in meta:
+        stroke_width = meta['edge_width']
     else:
-        edge_width = 1
+        stroke_width = 1
 
     if 'opacity' in meta:
         opacity = meta['opacity']
@@ -203,10 +207,10 @@ def points_to_xml(data, meta):
     # Find extrema of data
     extrema = np.array([points.min(axis=0), points.max(axis=0)])
 
-    props = {'stroke-width': str(edge_width), 'opacity': str(opacity)}
+    props = {'stroke-width': str(stroke_width), 'opacity': str(opacity)}
 
     xml_list = []
-    for p, s, fc, ec in zip(points, size, face_color, edge_color):
+    for p, s, fc, ec in zip(points, size, face_color, stroke_color):
         cx = str(p[1])
         cy = str(p[0])
         r = str(s / 2)

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -209,7 +209,10 @@ def points_to_xml(data, meta):
 
     # Ensure stroke width is an array to handle older versions of
     # napari (e.g. v0.4.0) where it could be a scalar.
-    stroke_width = np.broadcast_to(stroke_width, (data.shape[0],))
+    stroke_width = np.broadcast_to(stroke_width, (data.shape[0],)).copy()
+
+    if meta.get('border_width_is_relative', False):
+        stroke_width *= size
 
     xml_list = []
     for p, s, fc, sc, sw in zip(points, size, face_color, stroke_color, stroke_width):

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -210,14 +210,14 @@ def points_to_xml(data, meta):
     props = {'stroke-width': str(stroke_width), 'opacity': str(opacity)}
 
     xml_list = []
-    for p, s, fc, ec in zip(points, size, face_color, stroke_color):
+    for p, s, fc, sc in zip(points, size, face_color, stroke_color):
         cx = str(p[1])
         cy = str(p[0])
         r = str(s / 2)
         fc_int = (255 * fc).astype(int)
         fill = f'rgb{tuple(fc_int[:3])}'
-        ec_int = (255 * ec).astype(int)
-        stroke = f'rgb{tuple(ec_int[:3])}'
+        sc_int = (255 * sc).astype(int)
+        stroke = f'rgb{tuple(sc_int[:3])}'
         element = Element(
             'circle', cx=cx, cy=cy, r=r, stroke=stroke, fill=fill, **props
         )

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -191,7 +191,7 @@ def points_to_xml(data, meta):
     elif 'edge_width' in meta:
         stroke_width = meta['edge_width']
     else:
-        stroke_width = 1
+        stroke_width = np.ones((data.shape[0],))
 
     if 'opacity' in meta:
         opacity = meta['opacity']
@@ -207,10 +207,12 @@ def points_to_xml(data, meta):
     # Find extrema of data
     extrema = np.array([points.min(axis=0), points.max(axis=0)])
 
-    props = {'stroke-width': str(stroke_width), 'opacity': str(opacity)}
+    # Ensure stroke width is an array to handle older versions of
+    # napari (e.g. v0.4.0) where it could be a scalar.
+    stroke_width = np.broadcast_to(stroke_width, (data.shape[0],))
 
     xml_list = []
-    for p, s, fc, sc in zip(points, size, face_color, stroke_color):
+    for p, s, fc, sc, sw in zip(points, size, face_color, stroke_color, stroke_width):
         cx = str(p[1])
         cy = str(p[0])
         r = str(s / 2)
@@ -218,6 +220,10 @@ def points_to_xml(data, meta):
         fill = f'rgb{tuple(fc_int[:3])}'
         sc_int = (255 * sc).astype(int)
         stroke = f'rgb{tuple(sc_int[:3])}'
+        props = {
+            'stroke-width': str(sw),
+            'opacity': str(opacity),
+        }
         element = Element(
             'circle', cx=cx, cy=cy, r=r, stroke=stroke, fill=fill, **props
         )

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -211,7 +211,7 @@ def points_to_xml(data, meta):
     # napari (e.g. v0.4.0) where it could be a scalar.
     stroke_width = np.broadcast_to(stroke_width, (data.shape[0],)).copy()
 
-    if meta.get('border_width_is_relative', False):
+    if meta.get('border_width_is_relative') or meta.get('edge_width_is_relative'):
         stroke_width *= size
 
     xml_list = []


### PR DESCRIPTION
On napari's `main` branch, many of the `edge` state attributes that plugins used to receive were removed in favor of the equivalent `border` state attributes (https://github.com/napari/napari/pull/6402).

In the WIP https://github.com/napari/napari/pull/6976 , I added the `edge` attributes back in as deprecated keys in the state dictionary, which then caused a napari-svg test in napari to fail.

This PR fixes that failing test by checking for both the `edge` and `border` state. If it finds the `border` key (added from napari v0.5.0), it will use that, and if it doesn't it will fall back to the `edge` key. If it doesn't find either, it will fall back to some existing default.

This means that the napari-svg should handle this change correctly and without raising a warning. Before this PR, napari-svg was failing silently (by not picking up any defined edge properties) because the `edge` state is not present.

As part of this fix, I also discovered and fixed another bug, which is that `stroke-width` was being filled as an array for each circle in the SVG.

I added a test that compares the content of the SVG to an expected ground truth.