### PR TITLE
Support RGB images by using only first two elems of image shape

### DIFF
--- a/napari_svg/_tests/test_write_layer.py
+++ b/napari_svg/_tests/test_write_layer.py
@@ -95,6 +95,21 @@ def test_write_image_from_napari_layer_data(tmpdir, layer_writer_and_data):
     assert os.path.isfile(path)
 
 
+def test_write_rgb_image(tmp_path):
+    """Check that an rgb image can be correctly saved as svg."""
+    rng = np.random.default_rng(0)
+    image = np.random.randint(0, 256, size=(4, 4, 3), dtype=np.uint8)
+    path = tmp_path / 'rgb.svg'
+    return_path = napari_write_image(str(path), image, {'rgb': True})
+    assert str(path) == return_path
+    svg_txt = path.read_text()
+    assert 'data:image/png;base64' in svg_txt
+    # start and end of correct base64 encoding for this image
+    assert 'iVBOR' in svg_txt
+    assert 'uQmCC' in svg_txt
+
+
+
 def test_write_image_no_extension(tmpdir, layer_writer_and_data):
     """Test writing layer data with no extension."""
     writer, layer_data, _ = layer_writer_and_data

--- a/napari_svg/hook_implementations.py
+++ b/napari_svg/hook_implementations.py
@@ -143,7 +143,7 @@ def napari_write_image(path, data, meta):
     layer_xml, extrema = image_to_xml(data, meta)
     
     # Generate svg string
-    svg = xml_to_svg(layer_xml, extrema=extrema)
+    svg = xml_to_svg([layer_xml], extrema=extrema)
     
     # Write svg string
     with open(path, 'w') as file:

--- a/napari_svg/layer_to_xml.py
+++ b/napari_svg/layer_to_xml.py
@@ -113,7 +113,7 @@ def extrema_coords(coords, meta):
 
 def extrema_image(image, meta):
     """Compute the extrema of an image layer, accounting for transforms."""
-    coords = np.array([[0, 0], list(image.shape)])
+    coords = np.array([[0, 0], list(image.shape[:2])])
     return extrema_coords(coords, meta)
 
 


### PR DESCRIPTION
Takes now only the width and height of the image to calculate the extrema. This avoids an error when using color images